### PR TITLE
Use line comment by default

### DIFF
--- a/settings/language-nix.cson
+++ b/settings/language-nix.cson
@@ -1,0 +1,3 @@
+'.source.nix':
+  'editor':
+    'commentStart': '# '


### PR DESCRIPTION
This makes atom use "#" comment when using the "comment line" keyboard shortcut.
Not sure if it is the best way, but is it what e.g. atom-language-javascript does.
