### PR TITLE
Fix line comment setting

### DIFF
--- a/settings/language-nix.cson
+++ b/settings/language-nix.cson
@@ -1,3 +1,3 @@
-'.source.nix':
+'.nix.source':
   'editor':
     'commentStart': '# '


### PR DESCRIPTION
This makes Atom really toggle line comments by `⌘/` as was the original intent.